### PR TITLE
Close file in Kilo after save

### DIFF
--- a/src/kilo/kilo.cpp
+++ b/src/kilo/kilo.cpp
@@ -1010,6 +1010,7 @@ namespace ESP32Console::Kilo
 
         close(fd);*/
         free(buf);
+        fclose(file);
         E.dirty = 0;
         editorSetStatusMessage("%d bytes written on disk", len);
         return 0;


### PR DESCRIPTION
If file isn't closed, changes don't persist. Noticed when testing file creation/editing on SD card.

This fixes that problem (at least for me). I am testing on a [ESP-WROVER-KIT V4.1](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/esp32/get-started-wrover-kit.html) on PlatformIO with the following code:


    #include <Arduino.h>
    #include <ESP32Console.h>
    #include "ESP32Console/Helpers/PWDHelpers.h"
    #include "SD_MMC.h"
    using namespace ESP32Console;
    Console console;

    void setup() {
      // Set up console
      console.setPrompt(">> ");
      console.begin(115200);
      console.registerSystemCommands();
      console.registerNetworkCommands();
      console.registerVFSCommands();
      
      // Set up SD card
      SD_MMC.begin("/sd");
      console_chdir("/sd");
    }
    
    void loop() {
    
    }
