### PR TITLE
Update sysinfo command version info, and bump version

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "ESP32Console",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "Extensible UART console for ESP32 with useful included commands. This library encapsules the console component of ESP-IDF and make them easy to use in an Arduino environment.",
     "keywords": "esp32, console, ping, ifconfig, sysinfo, editor, file",
     "repository":

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ESP32Console
-version=1.2.1
+version=1.2.2
 author=Jan Böhmer <mail@jan-boehmer.de>
 maintainer=Jan Böhmer <mail@jan-boehmer.de>
 sentence=Extensible UART console for ESP32 with useful included commands.

--- a/src/ESP32Console.h
+++ b/src/ESP32Console.h
@@ -4,7 +4,7 @@
 #error This library depends on ESP-IDF and only works on ESP32!
 #endif
 
-#define ESP32CONSOLE_VERSION "1.1.0"
+#define ESP32CONSOLE_VERSION "1.2.2"
 
 #include "ESP32Console/Console.h"
 #include "ESP32Console/ConsoleCommand.h"


### PR DESCRIPTION
The past 2 updates (1.2.0 and 1.2.1) did not update the internal definition of the version number.

This commit bumps the library information to the next version that can be tagged, and sets the ESP32CONSOLE_VERSION macro up to date with the library information.

Resolves #14